### PR TITLE
Expand number of lines in collapsed posts

### DIFF
--- a/app/javascript/flavours/glitch/components/status.js
+++ b/app/javascript/flavours/glitch/components/status.js
@@ -6,6 +6,7 @@ import StatusHeader from './status_header';
 import StatusIcons from './status_icons';
 import StatusContent from './status_content';
 import StatusActionBar from './status_action_bar';
+import StatusExpandButton from './status_expand_button';
 import AttachmentList from './attachment_list';
 import Card from '../features/status/components/card';
 import { injectIntl, FormattedMessage } from 'react-intl';
@@ -793,6 +794,14 @@ class Status extends ImmutablePureComponent {
             tagLinks={settings.get('tag_misleading_links')}
             rewriteMentions={settings.get('rewrite_mentions')}
           />
+          {/* Only show expand button if collapsed and no spoiler tag is present */}
+          {isCollapsed && status.get('spoiler_text').length===0 ? (
+            <StatusExpandButton
+              hidden={isCollapsed}
+              handleSpoilerClick={parseClick}
+              mediaIcons={contentMediaIcons}
+            />
+          ) : null}
 
           {!isCollapsed || !(muted || !settings.getIn(['collapsed', 'show_action_bar'])) ? (
             <StatusActionBar

--- a/app/javascript/flavours/glitch/components/status_content.js
+++ b/app/javascript/flavours/glitch/components/status_content.js
@@ -7,6 +7,7 @@ import classnames from 'classnames';
 import Icon from 'flavours/glitch/components/icon';
 import { autoPlayGif } from 'flavours/glitch/initial_state';
 import { decode as decodeIDNA } from 'flavours/glitch/utils/idna';
+import StatusExpandButton from './status_expand_button';
 
 const textMatchesTarget = (text, origin, host) => {
   return (text === origin || text === host
@@ -289,38 +290,6 @@ export default class StatusContent extends React.PureComponent {
         </Permalink>
       )).reduce((aggregate, item) => [...aggregate, item, ' '], []);
 
-      let toggleText = null;
-      if (hidden) {
-        toggleText = [
-          <FormattedMessage
-            id='status.show_more'
-            defaultMessage='Show more'
-            key='0'
-          />,
-        ];
-        if (mediaIcons) {
-          mediaIcons.forEach((mediaIcon, idx) => {
-            toggleText.push(
-              <Icon
-                fixedWidth
-                className='status__content__spoiler-icon'
-                id={mediaIcon}
-                aria-hidden='true'
-                key={`icon-${idx}`}
-              />,
-            );
-          });
-        }
-      } else {
-        toggleText = (
-          <FormattedMessage
-            id='status.show_less'
-            defaultMessage='Show less'
-            key='0'
-          />
-        );
-      }
-
       if (hidden) {
         mentionsPlaceholder = <div>{mentionLinks}</div>;
       }
@@ -332,9 +301,11 @@ export default class StatusContent extends React.PureComponent {
           >
             <span dangerouslySetInnerHTML={spoilerContent} className='translate' lang={lang} />
             {' '}
-            <button type='button' className='status__content__spoiler-link' onClick={this.handleSpoilerClick} aria-expanded={!hidden}>
-              {toggleText}
-            </button>
+            <StatusExpandButton
+              hidden={hidden}
+              handleSpoilerClick={this.handleSpoilerClick}
+              mediaIcons={mediaIcons}
+            />
           </p>
 
           {mentionsPlaceholder}

--- a/app/javascript/flavours/glitch/components/status_expand_button.js
+++ b/app/javascript/flavours/glitch/components/status_expand_button.js
@@ -1,0 +1,71 @@
+import React from 'react';
+import { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import Icon from './icon';
+
+
+const StatusExpandButton=(
+  {
+    hidden,
+    handleSpoilerClick,
+    mediaIcons,
+  },
+)=>{
+  const makeToggleText = () => {
+    let newText;
+    if (hidden) {
+      newText = [
+        <FormattedMessage
+          id='status.show_more'
+          defaultMessage='Show more'
+          key='0'
+        />,
+      ];
+      if (mediaIcons) {
+        mediaIcons.forEach((mediaIcon, idx) => {
+          newText.push(
+            <Icon
+              fixedWidth
+              className='status__content__spoiler-icon'
+              id={mediaIcon}
+              aria-hidden='true'
+              key={`icon-${idx}`}
+            />,
+          );
+        });
+      }
+    } else {
+      newText = (
+        <FormattedMessage
+          id='status.show_less'
+          defaultMessage='Show less'
+          key='0'
+        />
+      );
+    }
+    return(newText);
+  };
+
+  // const [hidden, setHidden] = useState(false);
+  const [toggleText, setToggleText] = useState(makeToggleText());
+
+  // Change the text when the hidden state changes
+  useEffect(() => {
+    setToggleText(makeToggleText());
+  }, [hidden]);
+
+  return(
+    <button type='button' className='status__content__spoiler-link' onClick={handleSpoilerClick} aria-expanded={!hidden}>
+      {toggleText}
+    </button>
+  );
+};
+
+StatusExpandButton.propTypes = {
+  hidden: PropTypes.bool,
+  handleSpoilerClick: PropTypes.func,
+  mediaIcons: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default StatusExpandButton;

--- a/app/javascript/flavours/glitch/styles/components/status.scss
+++ b/app/javascript/flavours/glitch/styles/components/status.scss
@@ -393,22 +393,22 @@
     }
 
     .status__content {
-      height: 20px;
+      max-height: 6em;
       overflow: hidden;
       text-overflow: ellipsis;
-      padding-top: 0;
+      //padding-top: 0;
 
       &:after {
         content: "";
         position: absolute;
-        top: 0;
+        height: 40%;
         bottom: 0;
         left: 0;
         right: 0;
         background: linear-gradient(rgba($ui-base-color, 0), rgba($ui-base-color, 1));
         pointer-events: none;
       }
-      
+
       a:hover {
         text-decoration: none;
       }


### PR DESCRIPTION
also:
- add button to expand
- separate out collapse/expand button to be reused
- make gradient not full height of post

from:
https://neuromatch.social/@PessoaBrain/109530080695260906

Turns
<img width="813" alt="Screen Shot 2022-12-17 at 9 24 39 PM" src="https://user-images.githubusercontent.com/12961499/208283032-85a4afc7-6936-45fb-9fae-fb5c98b690a2.png">

into
<img width="810" alt="Screen Shot 2022-12-17 at 9 19 39 PM" src="https://user-images.githubusercontent.com/12961499/208283034-1de85c3c-ddbd-49ef-9fce-9a53782d70fa.png">

