### PR TITLE
[feature] Autofollow accounts in .env file on new account creation

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -294,6 +294,9 @@ MAX_POLL_OPTION_CHARS=100
 # HCAPTCHA_SECRET_KEY=
 # HCAPTCHA_SITE_KEY=
 
+# New registrations will automatically follow these accounts (separated by commas)
+AUTOFOLLOW=
+
 # IP and session retention
 # -----------------------
 # Make sure to modify the scheduling of ip_cleanup_scheduler in config/sidekiq.yml


### PR DESCRIPTION
All new accounts follow each account in a comma-separated list of accounts given in the .env file as `AUTOFOLLOW` :)