### PR TITLE
[feature] fetch all replies

### DIFF
--- a/app/javascript/flavours/glitch/actions/search.js
+++ b/app/javascript/flavours/glitch/actions/search.js
@@ -27,9 +27,9 @@ export function clearSearch() {
   };
 };
 
-export function submitSearch() {
+export function submitSearch(search) {
   return (dispatch, getState) => {
-    const value    = getState().getIn(['search', 'value']);
+    const value    = search ? search : getState().getIn(['search', 'value']);
     const signedIn = !!getState().getIn(['meta', 'me']);
 
     if (value.length === 0) {

--- a/app/javascript/flavours/glitch/actions/statuses.js
+++ b/app/javascript/flavours/glitch/actions/statuses.js
@@ -4,6 +4,7 @@ import { deleteFromTimelines } from './timelines';
 import { importFetchedStatus, importFetchedStatuses } from './importer';
 import { ensureComposeIsVisible, setComposeToStatus } from './compose';
 import { submitSearch } from './search';
+import { showAlert } from './alerts';
 
 export const STATUS_FETCH_REQUEST = 'STATUS_FETCH_REQUEST';
 export const STATUS_FETCH_SUCCESS = 'STATUS_FETCH_SUCCESS';
@@ -238,6 +239,7 @@ export function fetchExternalContext(status_url, id){
     dispatch(fetchExternalContextRequest(id));
 
     api(getState).get(`${origin}/api/v1/statuses/${external_id}/context`).then(response => {
+      dispatch(showAlert('Getting Replies...', `Getting ${response.data.descendants.length} Replies.`));
       response.data.descendants.forEach((status) => {
         dispatch(submitSearch(status.url));
       });

--- a/app/javascript/flavours/glitch/features/status/index.js
+++ b/app/javascript/flavours/glitch/features/status/index.js
@@ -8,6 +8,7 @@ import { createSelector } from 'reselect';
 import { fetchStatus } from 'flavours/glitch/actions/statuses';
 import MissingIndicator from 'flavours/glitch/components/missing_indicator';
 import LoadingIndicator from 'flavours/glitch/components/loading_indicator';
+import Button from 'flavours/glitch/components/button';
 import DetailedStatus from './components/detailed_status';
 import ActionBar from './components/action_bar';
 import Column from 'flavours/glitch/features/ui/components/column';
@@ -36,6 +37,7 @@ import {
   revealStatus,
   translateStatus,
   undoStatusTranslation,
+  fetchExternalContext,
 } from 'flavours/glitch/actions/statuses';
 import { initMuteModal } from 'flavours/glitch/actions/mutes';
 import { initBlockModal } from 'flavours/glitch/actions/blocks';
@@ -463,6 +465,12 @@ class Status extends ImmutablePureComponent {
     this.props.dispatch(openModal('EMBED', { url: status.get('url') }));
   }
 
+  handleFetchContext = () => {
+    const { status, statusId } = this.props;
+    this.props.dispatch(fetchExternalContext(status.get('url'), statusId));
+    this.forceUpdate();
+  }
+
   handleHotkeyToggleSensitive = () => {
     this.handleToggleMediaVisibility();
   }
@@ -707,6 +715,24 @@ class Status extends ImmutablePureComponent {
             </HotKeys>
 
             {descendants}
+
+            {isLocal
+              ? null
+              : <div style={{
+                display: 'block',
+                margin: '1em 1em',
+                }}
+              >
+                <Button
+                className={'primary'}
+                text={'Get More Replies'}
+                title={'Get More Replies'}
+                onClick={this.handleFetchContext}
+                block
+                />
+              </div>
+            }
+
           </div>
         </ScrollContainer>
 

--- a/app/javascript/flavours/glitch/reducers/contexts.js
+++ b/app/javascript/flavours/glitch/reducers/contexts.js
@@ -6,6 +6,7 @@ import { CONTEXT_FETCH_SUCCESS } from 'flavours/glitch/actions/statuses';
 import { TIMELINE_DELETE, TIMELINE_UPDATE } from 'flavours/glitch/actions/timelines';
 import { Map as ImmutableMap, List as ImmutableList } from 'immutable';
 import compareId from '../compare_id';
+import { SEARCH_FETCH_SUCCESS } from '../actions/search';
 
 const initialState = ImmutableMap({
   inReplyTos: ImmutableMap(),
@@ -88,6 +89,13 @@ const updateContext = (state, status) => {
   return state;
 };
 
+const updateContexts = (state, statuses) => {
+  statuses.forEach((status) => {
+    state = updateContext(state, status);
+  });
+  return state;
+};
+
 export default function replies(state = initialState, action) {
   switch(action.type) {
   case ACCOUNT_BLOCK_SUCCESS:
@@ -99,6 +107,8 @@ export default function replies(state = initialState, action) {
     return deleteFromContexts(state, [action.id]);
   case TIMELINE_UPDATE:
     return updateContext(state, action.status);
+  case SEARCH_FETCH_SUCCESS: //STATUSES_IMPORT: // eg. from external context expansion
+    return updateContexts(state, action.results.statuses);
   default:
     return state;
   }


### PR DESCRIPTION
Adds a button to the bottom of an expanded status to fetch all replies from the OP server (or as many as they will give us).

- Example: https://neuromatch.social/@jonny/109582537808504261
- Context: https://neuromatch.social/tags/FetchAllReplies
- Wiki: https://wiki.neuromatch.io/Fetch_All_Replies

The feature:
- Tries to figure out the API URL for the OP server (currently just using the masto pattern, consider that a TODO)
- Fetches the replies from the /statuses/{:id}/context endpoint
- Uses the search API on the host instance in order to fetch the necessary status and account information to display the status.

It also:
- Displays a dialogue box showing how many statuses it is grabbing

Still to do:
- Write tests (dont know hwo to do that in ruby)
- Catch errors better
- Insert into thread in correct order (refreshing fixes)