### PR TITLE
better code blocks

### DIFF
--- a/app/javascript/flavours/glitch/styles/forms.scss
+++ b/app/javascript/flavours/glitch/styles/forms.scss
@@ -2,7 +2,9 @@ $no-columns-breakpoint: 600px;
 
 code {
   font-family: $font-monospace, monospace;
-  font-weight: 400;
+  border-radius: 3px;
+  padding: 0 0.4em;
+  background: darken($ui-base-color, 8%);
 }
 
 .form-container {
@@ -1101,4 +1103,32 @@ code {
     margin-top: 10px;
     white-space: nowrap;
   }
+}
+
+pre {
+  background: darken($ui-base-color, 8%);
+  border-radius: 3px;
+  padding: 0.75em;
+  counter-reset: line;
+  overflow-x: scroll;
+}
+
+pre code {
+  counter-increment: line;
+  padding: 0;
+  white-space: pre;
+}
+
+pre code::before {
+  font-size: 0.8em;
+  color: darken($primary-text-color, 33%);
+  content: counter(line);
+  display: inline-block;
+  border-right: 1px solid darken($primary-text-color, 33%);
+  margin: -0.05em 0.7em -0.05em 0;
+  padding: 0.05em 0.5em 0.05em 0;
+  text-align: right;
+  width: 1.2em;
+  white-space: nowrap;
+  direction: rtl;
 }

--- a/app/lib/advanced_text_formatter.rb
+++ b/app/lib/advanced_text_formatter.rb
@@ -9,7 +9,7 @@ class AdvancedTextFormatter < TextFormatter
 
     def block_code(code, _language)
       <<~HTML
-        <pre><code>#{ERB::Util.h(code).gsub("\n", '<br/>')}</code></pre>
+        <pre><code>#{ERB::Util.h(code.rstrip).gsub("\n", '</code></br><code>')}</code></pre>
       HTML
     end
 


### PR DESCRIPTION
Minor tweak to the code block formatting & css which...
- makes both inline code and code blocks more visible
- adds line numbers, which shouldn't be selectable/copyable, to code blocks
- makes code blocks scroll horizontally for long lines, rather than wrapping text

<img width="382" alt="Screen Shot 2022-12-28 at 03 38 41" src="https://user-images.githubusercontent.com/20880695/209787156-e4d33b70-e1a8-4406-b4b5-11c58935a850.png">
<img width="376" alt="Screen Shot 2022-12-28 at 03 37 54" src="https://user-images.githubusercontent.com/20880695/209787158-f14b2316-ee29-48d5-a8f3-1ca860f9d344.png">
<img width="381" alt="Screen Shot 2022-12-28 at 03 37 45" src="https://user-images.githubusercontent.com/20880695/209787159-6ad5e5b9-21a1-4a60-8b5c-95f396e22bf6.png">