### PR TITLE
Upstream updates pr action

### DIFF
--- a/.github/workflows/upstream-changes-pr.yml
+++ b/.github/workflows/upstream-changes-pr.yml
@@ -27,10 +27,11 @@ jobs:
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "Github Actions"
-          git remote add upstream https://github.com/spectral-discord/DisMAL.js
+          git merge origin/main
+          git remote add upstream https://github.com/glitch-soc/mastodon
           git fetch upstream
           git merge upstream/main
-          changes=$(git push origin)
+          changes=$(git push origin 2>&1)
           if [ "$changes" = "Everything up-to-date" ]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/upstream-changes-pr.yml
+++ b/.github/workflows/upstream-changes-pr.yml
@@ -1,0 +1,65 @@
+name: Upstream Changes PR
+
+permissions: write-all
+
+on: 
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+    steps: 
+      - name: Create Branch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        with:
+          branch: unmerged-upstream
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: unmerged-upstream
+          fetch-depth: 0 
+      - name: Rebase to Upstream
+        uses: zhangnew/sync-upstream@v1
+        with:
+          upstream: glitch-soc/mastodon
+          upstream-branch: main
+          branch: unmerged-upstream
+      - name: Check if PR exists
+        env: 
+          GH_TOKEN: ${{ github.token }}
+        id: check
+        run: |
+          prs=$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --json baseRefName,headRefName \
+            --jq '
+              map(select(.baseRefName == "dev" and .headRefName == "unmerged-upstream"))
+              | length
+            ')
+          if ((prs > 0)); then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Create Pull Request
+        if: '!steps.check.outputs.skip'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const result = await github.rest.pulls.create({
+              title: 'Merge Upstream Changes',
+              owner,
+              repo,
+              head: 'unmerged-upstream',
+              base: 'main',
+              body: 'This PR was *auto-generated* by the `Upstream Changes PR` action and contains unmerged changes from the upstream [glitch-soc](https://github.com/glitch-soc/mastodon) repository.'
+            });
+            github.rest.issues.addLabels({
+              owner,
+              repo,
+              issue_number: result.data.number,
+              labels: ['upstream', 'automated pr']
+            });

--- a/.github/workflows/upstream-changes-pr.yml
+++ b/.github/workflows/upstream-changes-pr.yml
@@ -22,12 +22,18 @@ jobs:
         with:
           ref: unmerged-upstream
           fetch-depth: 0 
-      - name: Rebase to Upstream
-        uses: zhangnew/sync-upstream@v1
-        with:
-          upstream: glitch-soc/mastodon
-          upstream-branch: main
-          branch: unmerged-upstream
+      - name: Merge Upstream
+        id: merge
+        run: |
+          git config --local user.email "actions@github.com"
+          git config --local user.name "Github Actions"
+          git remote add upstream https://github.com/spectral-discord/DisMAL.js
+          git fetch upstream
+          git merge upstream/main
+          changes=$(git push origin)
+          if [ "$changes" = "Everything up-to-date" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Check if PR exists
         env: 
           GH_TOKEN: ${{ github.token }}
@@ -44,7 +50,9 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Create Pull Request
-        if: '!steps.check.outputs.skip'
+        if: |
+          !steps.check.outputs.skip &&
+          !steps.merge.outputs.skip
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
a github action that does the following:
- creates a branch called `unmerged-upstream` if one doesn't exist already
- attempts to merge changes from upstream glitch's `main` branch into `unmerged-upstream`, and pushes to github
  - the merge will fail for some merge conflict cases, in which case the conflicts will need to be resolved via cli or some other method
- it creates a PR for merging `unmerged-upstream` into `dev` if one doesn't exist already (and as long as there were actually changes that got merged into `unmerged-upstream`)

I made it so this flow can be triggered in two ways:
- via a scheduled/"cron" that's currently set to trigger every Sunday at midnight (which can be changed ofc)
- manually via the repo's actions panel

I set the PR's title to be "Merge Upstream Changes", gave it a couple labels (`upstream` & `automated pr`), and its body looks like the following (any of these can be changed ofc):

This PR was *auto-generated* by the `Upstream Changes PR` action and contains unmerged changes from the upstream [glitch-soc](https://github.com/glitch-soc/mastodon) repository.