### PR TITLE
Make alt text limit an .env parameter

### DIFF
--- a/.env.production.sample
+++ b/.env.production.sample
@@ -248,8 +248,11 @@ SMTP_FROM_ADDRESS=notifications@example.com
 # Various ways to customize Mastodon's behavior
 # ---------------
 
-# Maximum allowed character count
+# Maximum allowed character count in posts
 MAX_TOOT_CHARS=500
+
+# Maximum allowed character count in alt text
+MAX_ALT_TEXT_CHARS=1500
 
 # Maximum number of pinned posts
 MAX_PINNED_TOOTS=5

--- a/app/javascript/flavours/glitch/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/flavours/glitch/features/ui/components/focal_point_modal.jsx
@@ -22,6 +22,7 @@ import tesseractCorePath from 'tesseract.js-core/tesseract-core.wasm.js';
 // eslint-disable-next-line import/extensions
 import tesseractWorkerPath from 'tesseract.js/dist/worker.min.js';
 import { assetHost } from 'flavours/glitch/utils/config';
+import { maxAltTextChars } from 'flavours/glitch/initial_state';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
@@ -361,7 +362,7 @@ class FocalPointModal extends ImmutablePureComponent {
 
             <div className='setting-text__toolbar'>
               <button disabled={detecting || media.get('type') !== 'image' || is_changing_upload} className='link-button' onClick={this.handleTextDetection}><FormattedMessage id='upload_modal.detect_text' defaultMessage='Detect text from picture' /></button>
-              <CharacterCounter max={1500} text={detecting ? '' : description} />
+              <CharacterCounter max={maxAltTextChars} text={detecting ? '' : description} />
             </div>
 
             <Button disabled={!dirty || detecting || isUploadingThumbnail || length(description) > 1500 || is_changing_upload} text={intl.formatMessage(is_changing_upload ? messages.applying : messages.apply)} onClick={this.handleSubmit} />

--- a/app/javascript/flavours/glitch/initial_state.js
+++ b/app/javascript/flavours/glitch/initial_state.js
@@ -145,6 +145,7 @@ export const statusPageUrl = getMeta('status_page_url');
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;
+export const maxAltTextChars = (initialState && initialState.max_alt_text_chars) || 1_500;
 export const favouriteModal = getMeta('favourite_modal');
 export const pollLimits = (initialState && initialState.poll_limits);
 export const defaultContentType = getMeta('default_content_type');

--- a/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
+++ b/app/javascript/mastodon/features/ui/components/focal_point_modal.jsx
@@ -23,6 +23,7 @@ import tesseractCorePath from 'tesseract.js-core/tesseract-core.wasm.js';
 // eslint-disable-next-line import/extensions
 import tesseractWorkerPath from 'tesseract.js/dist/worker.min.js';
 import { assetHost } from 'mastodon/utils/config';
+import { maxAltTextChars } from '../../../initial_state';
 
 const messages = defineMessages({
   close: { id: 'lightbox.close', defaultMessage: 'Close' },
@@ -369,7 +370,7 @@ class FocalPointModal extends ImmutablePureComponent {
               >
                 <FormattedMessage id='upload_modal.detect_text' defaultMessage='Detect text from picture' />
               </button>
-              <CharacterCounter max={1500} text={detecting ? '' : description} />
+              <CharacterCounter max={maxAltTextChars} text={detecting ? '' : description} />
             </div>
 
             <Button

--- a/app/javascript/mastodon/initial_state.js
+++ b/app/javascript/mastodon/initial_state.js
@@ -136,5 +136,7 @@ export const statusPageUrl = getMeta('status_page_url');
 
 // Glitch-soc-specific settings
 export const maxChars = (initialState && initialState.max_toot_chars) || 500;
+export const maxAltTextChars = (initialState && initialState.max_alt_text_chars) || 1_500;
+
 
 export default initialState;

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -37,7 +37,7 @@ class MediaAttachment < ApplicationRecord
   enum type: { :image => 0, :gifv => 1, :video => 2, :unknown => 3, :audio => 4 }
   enum processing: { :queued => 0, :in_progress => 1, :complete => 2, :failed => 3 }, _prefix: true
 
-  MAX_DESCRIPTION_LENGTH = 1_500
+  MAX_DESCRIPTION_LENGTH = (ENV['MAX_ALT_TEXT_CHARS'] || 1_500).to_i
 
   IMAGE_LIMIT = (ENV['MAX_IMAGE_SIZE'] || 10.megabytes).to_i
   VIDEO_LIMIT = (ENV['MAX_VIDEO_SIZE'] || 40.megabytes).to_i
@@ -199,7 +199,7 @@ class MediaAttachment < ApplicationRecord
   remotable_attachment :thumbnail, IMAGE_LIMIT, suppress_errors: true, download_on_assign: false
 
   validates :account, presence: true
-  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }
+  validates :description, length: { maximum: MAX_DESCRIPTION_LENGTH }, if: :local?
   validates :file, presence: true, if: :local?
   validates :thumbnail, absence: true, if: -> { local? && !audio_or_video? }
 

--- a/app/serializers/initial_state_serializer.rb
+++ b/app/serializers/initial_state_serializer.rb
@@ -6,13 +6,17 @@ class InitialStateSerializer < ActiveModel::Serializer
   attributes :meta, :compose, :accounts,
              :media_attachments, :settings,
              :max_toot_chars, :poll_limits,
-             :languages
+             :languages, :max_alt_text_chars
 
   has_one :push_subscription, serializer: REST::WebPushSubscriptionSerializer
   has_one :role, serializer: REST::RoleSerializer
 
   def max_toot_chars
     StatusLengthValidator::MAX_CHARS
+  end
+
+  def max_alt_text_chars
+    MediaAttachment::MAX_DESCRIPTION_LENGTH
   end
 
   def poll_limits

--- a/app/serializers/rest/instance_serializer.rb
+++ b/app/serializers/rest/instance_serializer.rb
@@ -66,6 +66,7 @@ class REST::InstanceSerializer < ActiveModel::Serializer
         video_size_limit: MediaAttachment::VIDEO_LIMIT,
         video_frame_rate_limit: MediaAttachment::MAX_VIDEO_FRAME_RATE,
         video_matrix_limit: MediaAttachment::MAX_VIDEO_MATRIX_LIMIT,
+        max_alt_text_characters: MediaAttachment::MAX_DESCRIPTION_LENGTH
       },
 
       polls: {

--- a/app/serializers/rest/v1/instance_serializer.rb
+++ b/app/serializers/rest/v1/instance_serializer.rb
@@ -4,7 +4,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
   include RoutingHelper
 
   attributes :uri, :title, :short_description, :description, :email,
-             :version, :urls, :stats, :thumbnail, :max_toot_chars, :poll_limits,
+             :version, :urls, :stats, :thumbnail, :max_toot_chars, :max_alt_text_chars, :poll_limits,
              :languages, :registrations, :approval_required, :invites_enabled,
              :configuration
 
@@ -38,6 +38,10 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
 
   def max_toot_chars
     StatusLengthValidator::MAX_CHARS
+  end
+
+  def max_alt_text_chars
+    MediaAttachment::MAX_DESCRIPTION_LENGTH
   end
 
   def poll_limits
@@ -89,6 +93,7 @@ class REST::V1::InstanceSerializer < ActiveModel::Serializer
         video_size_limit: MediaAttachment::VIDEO_LIMIT,
         video_frame_rate_limit: MediaAttachment::MAX_VIDEO_FRAME_RATE,
         video_matrix_limit: MediaAttachment::MAX_VIDEO_MATRIX_LIMIT,
+        max_alt_text_characters: MediaAttachment::MAX_DESCRIPTION_LENGTH
       },
 
       polls: {


### PR DESCRIPTION
Alt text should be able to be one million characters long. This pull requests lets the alt text limit be set from .env as `MAX_ALT_TEXT_CHARS` (defaulting to the current 1500.

<img width="984" alt="Mastodon image description window describing a green bordered image with italic text that says 'alt text character limits should be one million'" src="https://user-images.githubusercontent.com/12961499/230520830-35f97340-e85e-4dc6-81c1-90cdbe1d1f61.png">

Also added to `/api/instance` and `/api/v1/instance`

<img width="461" alt="JSON response from the /api/instance endpoint that shows a new field max_alt_text_characters in configuration.media_attachments" src="https://user-images.githubusercontent.com/12961499/230520899-fcc712f0-24b1-4369-9e12-9e3e612ff730.png">


Alt text config implementation:
- Set in .env (with example in .env.production.sample)
- Set in Rails in `MediaAttachment` model as `MAX_DESCRIPTION_LENGTH` by reading from ENV
- Read by Rails in `initial_state_serializer` and `instance_serializer` for both v1 and v2 apis
- Transferred to js from initialState as `maxAltTextChars`
- Used in focal_point_modal to display.

API Changes:
- `/api/v1/instance`
  - `max_alt_text_characters`
  - `configuration.media_attachments.max_alt_text_characters`
- `/api/instance`
  - `configuration.media_attachments.max_alt_text_characters`

Also fixed an unexplained reversion in https://github.com/mastodon/mastodon/commit/71f2b95106b2e75d3efb40040b29c216c2d99ee6 that invalidates alt text that is longer than the local limit.