### PR TITLE
[Hotfix] MathJaX configuration with CSP nonce

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,17 +35,19 @@
     = csrf_meta_tags unless skip_csrf_meta_tags?
     %meta{ name: 'style-nonce', content: request.content_security_policy_nonce }
 
-    :javascript
-      var nonce = document.querySelector('meta[name="style-nonce"]').getAttribute('content');
-      window.MathJax = {
-        chtml: {nonce: nonce},
-        tex: {
-          processEnvironments: false,
-          processRefs: false,
-          inlineMath: [['\\(', '\\)']],
-          displayMath: [['\\[', '\\]']]
+    %script{ nonce: request.content_security_policy_nonce }
+      :plain
+        var nonce = document.querySelector('meta[name="style-nonce"]').getAttribute('content');
+        window.MathJax = {
+          chtml: {nonce: nonce},
+          tex: {
+            processEnvironments: false,
+            processRefs: false,
+            inlineMath: [['\\(', '\\)']],
+            displayMath: [['\\[', '\\]']]
           }
         };
+
     %script{ src: '/MathJax/es5/tex-chtml.js' }
 
     = stylesheet_link_tag '/inert.css', skip_pipeline: true, media: 'all', id: 'inert-style'

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -86,7 +86,7 @@ end
 
 Rails.application.config.content_security_policy_nonce_generator = ->request { SecureRandom.base64(16) }
 
-Rails.application.config.content_security_policy_nonce_directives = %w(style-src)
+Rails.application.config.content_security_policy_nonce_directives = %w(style-src script-src)
 
 Rails.application.reloader.to_prepare do
   PgHero::HomeController.content_security_policy do |p|

--- a/spec/requests/content_security_policy_spec.rb
+++ b/spec/requests/content_security_policy_spec.rb
@@ -21,7 +21,7 @@ describe 'Content-Security-Policy' do
       "child-src 'self' blob: https://cb6e6126.ngrok.io",
       "worker-src 'self' blob: https://cb6e6126.ngrok.io",
       "connect-src 'self' blob: data: ws://localhost:4000 https://cb6e6126.ngrok.io",
-      "script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval'"
+      "script-src 'self' https://cb6e6126.ngrok.io 'wasm-unsafe-eval' 'nonce-ZbA+JmE7+bK8F5qvADZHuQ=='"
     )
   end
 end


### PR DESCRIPTION
Fixes https://github.com/NeuromatchAcademy/mastodon/issues/32

- Adds nonce to inline js script tag 
- Allows inline js with nonce

Part of: https://wiki.neuromatch.social/Mastodon/Mathjax