### PR TITLE
Resize videos larger than max allowed resolution

### DIFF
--- a/app/models/concerns/attachmentable.rb
+++ b/app/models/concerns/attachmentable.rb
@@ -6,7 +6,9 @@ module Attachmentable
   extend ActiveSupport::Concern
 
   MAX_MATRIX_LIMIT = 33_177_600 # 7680x4320px or approx. 847MB in RAM
-  GIF_MATRIX_LIMIT = 921_600    # 1280x720px
+  MAX_GIF_WIDTH = 3840
+  MAX_GIF_HEIGHT = 2160
+  GIF_MATRIX_LIMIT = MAX_GIF_WIDTH * MAX_GIF_HEIGHT
 
   # For some file extensions, there exist different content
   # type variants, and browsers often send the wrong one,


### PR DESCRIPTION
Context: https://neuromatch.social/@elduvelle/111597148157826926

We want to let people post larger media here, the question is how large?

The current configuration options actually don't modify some of the underlying behavior for handling gifs, and the current behavior is to just reject gifs/videos larger than the max rather than trying to rescale them.

This PR:

- Increases the maximum allowed sizes for GIFs
- Creates two tiers of maximums: this allows us to accept a wider range of sizes without the server attempting to transcode an adversarially sized memory bomb.
  - media smaller than the first maximum: unchanged
  - media larger than the first maximum: rescaled down to the maximum, preserving aspect ratio
  - media larger than the second maximum: rejected

