### PR TITLE
[Bugfix] Make filter boosts respect local vs. remote scope

### DIFF
--- a/db/migrate/20240129222920_add_index_reblog_of_id_and_status_to_statuses.rb
+++ b/db/migrate/20240129222920_add_index_reblog_of_id_and_status_to_statuses.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexReblogOfIdAndStatusToStatuses < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :statuses, [:reblog_of_id, :id], order: { reblog_of_id: 'DESC NULLS LAST', id: 'DESC' }, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_07_150100) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_29_222920) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -993,6 +993,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_07_150100) do
     t.index ["in_reply_to_account_id"], name: "index_statuses_on_in_reply_to_account_id", where: "(in_reply_to_account_id IS NOT NULL)"
     t.index ["in_reply_to_id"], name: "index_statuses_on_in_reply_to_id", where: "(in_reply_to_id IS NOT NULL)"
     t.index ["reblog_of_id", "account_id"], name: "index_statuses_on_reblog_of_id_and_account_id"
+    t.index ["reblog_of_id", "id"], name: "index_statuses_on_reblog_of_id_and_id", order: { reblog_of_id: "DESC NULLS LAST", id: :desc }
     t.index ["uri"], name: "index_statuses_on_uri", unique: true, opclass: :text_pattern_ops, where: "(uri IS NOT NULL)"
   end
 

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -62,16 +62,15 @@ RSpec.describe PublicFeed do
 
       it 'filters duplicate boosts across pagination' do
         status = Fabricate(:status, account: poster)
-        # sleep for 2ms to make sure the other posts come in a greater snowflake ID
-        sleep(0.002)
 
-        boost = Fabricate(:status, reblog_of_id: status.id, account: poster)
+        boost = Fabricate(:status, reblog_of_id: status.id, id: status.id + 1, account: poster)
 
         # sleep for 2ms to make sure the other posts come in a greater snowflake ID
         sleep(0.002)
 
-        (1..20).each do |_i|
-          Fabricate(:status, account: poster)
+        n_posts = 20
+        (1..n_posts).each do |i|
+          Fabricate(:status, account: poster, id: boost.id + i)
         end
 
         # before a second boost, the second page should still include the original boost
@@ -79,20 +78,37 @@ RSpec.describe PublicFeed do
         expect(second_page).to include(boost.id)
 
         # after a second boost, the second page should no longer include the original boost
-        second_boost = Fabricate(:status, reblog_of_id: status.id, account: booster)
+        second_boost = Fabricate(:status, reblog_of_id: status.id, id: boost.id + n_posts + 1, account: booster)
         second_page = described_class.new(nil, with_reblogs: true).get(20, boost.id + 1).map(&:id)
 
         expect(subject).to include(second_boost.id)
         expect(second_page).to_not include(boost.id)
       end
 
-      it 'shows the most recent local boost when there is a more recent remote boost' do
-        status = Fabricate(:status, account: poster)
-        local_boost = Fabricate(:status, reblog_of_id: status.id, local: true, account: booster)
-        remote_boost = Fabricate(:status, reblog_of_id: status.id, id: local_boost.id + 1, local: false, uri: 'https://example.com/boosturl', account: remote_booster)
+      context 'with local option' do
+        subject { described_class.new(nil, with_reblogs: true, local: true, remote: false).get(20).map(&:id) }
 
-        expect(subject).to include(local_boost.id)
-        expect(subject).to_not include(remote_boost.id)
+        it 'shows the most recent local boost when there is a more recent remote boost' do
+          status = Fabricate(:status, account: poster)
+          local_boost = Fabricate(:status, reblog_of_id: status.id, local: true, account: booster)
+          remote_boost = Fabricate(:status, reblog_of_id: status.id, id: local_boost.id + 1, local: false, uri: 'https://example.com/boosturl', account: remote_booster)
+
+          expect(subject).to include(local_boost.id)
+          expect(subject).to_not include(remote_boost.id)
+        end
+      end
+
+      context 'with remote option' do
+        subject { described_class.new(nil, with_reblogs: true, local: false, remote: true).get(20).map(&:id) }
+
+        it 'shows the most recent remote boost when there is a more recent local boost' do
+          status = Fabricate(:status, account: poster)
+          remote_boost = Fabricate(:status, reblog_of_id: status.id, local: false, uri: 'https://example.com/boosturl', account: remote_booster)
+          local_boost = Fabricate(:status, reblog_of_id: status.id, id: remote_boost.id + 1, local: true, account: booster)
+
+          expect(subject).to include(remote_boost.id)
+          expect(subject).to_not include(local_boost.id)
+        end
       end
     end
 


### PR DESCRIPTION
Closes: https://github.com/NeuromatchAcademy/mastodon/issues/37
Continues: https://github.com/NeuromatchAcademy/mastodon/pull/36

The first version of filter duplicate boosts forgot to take the max of only local or remote scopes, so if a post had been boosted more recently by a remote account, the most recent local boost wouldn't be seen and vice versa for the federated feed. This fixes that by including those scopes in the correlated subquery.

**Caveats:** 
- I was able to figure out how to express correlated subqueries using Arel, but try as I might, I wasn't able to figure out how to change the table alias of the contexts from `Status` when used in the subquery (so rather than `WHERE s2.local = true` it would always be `WHERE statuses.local = true`, which didn't work). This means that if the definition of the contexts change, then our subquery will get out of sync, but if that happens the tests should catch us.

**Other changes**
- Add a multicolumn index on `reblog_of_id` and `id` to make subquery faster!
- Move the `scope.merge!` call out of the block of other scopes so that it's easier to maintain - fewer merge conflicts
- split scope into two scopes to match rest of structure which only has one scope per method
- remove crappy sleep hack to ensure monotonic increase of IDs, just manually increment them.
- explicit rspec contexts for local and remote feeds

I am not sure why the ruby linting is failing now, but i didn't touch any of those files - we'll sort of linter errors when we merge upstream tomorrow