### PR TITLE
[style] fix status button background color

### DIFF
--- a/app/javascript/flavours/glitch/styles/neuromatchstodon/bigger_collapsed_statuses.scss
+++ b/app/javascript/flavours/glitch/styles/neuromatchstodon/bigger_collapsed_statuses.scss
@@ -20,3 +20,9 @@
     }
   }
 }
+
+// Fix background color after upstream moved how the
+// normal button is placed in the DOM
+.status.collapsed .status__content__spoiler-link {
+  background: $action-button-color;
+}


### PR DESCRIPTION
Recent update changed the way the status DOM structure works, so a css rule misses setting the background color on the "show more" button for collapsed posts and it now looks like this:


https://github.com/NeuromatchAcademy/mastodon/assets/12961499/fd120901-d373-431d-b978-c6b39437d1f1

this PR just adds an explicit rule to set the background color.