### PR TITLE
Towards a usable discovery algo

### DIFF
--- a/app/models/concerns/status/threading_concern.rb
+++ b/app/models/concerns/status/threading_concern.rb
@@ -28,6 +28,10 @@ module Status::ThreadingConcern
     find_statuses_from_tree_path(descendant_ids(limit, depth), account, promote: true)
   end
 
+  def descendants_count
+    descendant_ids('ALL', nil).length
+  end
+
   def self_replies(limit)
     account.statuses.distributable_visibility.where(in_reply_to_id: id).reorder(id: :asc).limit(limit)
   end

--- a/app/models/trends/base.rb
+++ b/app/models/trends/base.rb
@@ -88,7 +88,7 @@ class Trends::Base
   private
 
   def used_key(at_time)
-    "#{key_prefix}:used:#{at_time.beginning_of_day.to_i}"
+    "#{key_prefix}:used:#{at_time.days_ago(1).to_i}"
   end
 
   def rename_set(pipeline, from_key, to_key, set_items)


### PR DESCRIPTION
Step 1, background for making the /about page friendlier is trying to surface recent discussions from the instance. first i wanted to make the discover page usable at all, and then i'll add a filter to only include posts from the instance.

Currently the discovery page is sort of sad, doesn't really work for smaller instances because the values are all tuned for mastodon social.

- posts decay too quickly to be seen with a 1 hour half life - this puts most posts beneath the 5 score threshold most of the time. 
- we want to surface posts that generate good discussion i think, but replies are not accounted for in the score
- likes are weighted the same as boosts, even though most people think of favorites as being 'read receipts' with a boost being more meaningful.
- there is problem in the way that it picks posts that makes it so there is a discontinuity around midnight UTC thanks to the use of `beginning_of_day` rather than `days_ago(1)`

So this PR
- adds a `descendents_count` method to Status that counts all replies in a tree, rather than immediate replies
- adds an additional parameter to the update method to allow for statuses that haven't been used in the redis cache in 3 days to be considered for the explore feed (i couldn't find documentation for `used` key in redis but i'm assuming it's last time it's accessed)
- increases the halflife from 1 hour to 12 hours, this spreads out time for consideration and importantly allows us to account for timezone differences
- adds weights for different kinds of interactions
- moves the `interaction_exponent` out of the function into the options - i feel like this should be an exponent <1 where there is some ceiling for interaction counts mattering rather than making them matter more at higher values, but i didn't want to change too much without simulating
- makes a `local_weight` value that amplifies posts from within the instance
- allows replies to be shown in the explore feed - some of the best discussion happens in replies. kept the requirement that they be public visibility since the docs for the unlisted setting explicitly say you won't be included in the algo feed, but replies to someone else's post in public visibility don't clog the local feed so using public visibility in replies not to yourself is good to do.

Here's the worst matplotlib plot you've ever seen showing some values of favorites, replies, and boosts over a week and how those scores decay with time. i split it out into 3 subplots for number of favorites bc there were too many lines in a single plot, and the legends say how many boosts or replies for each post. another way of reading this is to "slide each line across time" to see when a post with a smaller number of interactions would have a higher rank than an older post with more interactions, and that's sort of a proxy for the discovery churn.

<img width="979" alt="Screenshot 2024-09-14 at 10 54 15 PM" src="https://github.com/user-attachments/assets/4620cf3c-6246-4703-8857-9817a3bed342">

@thesamovar wdyt

