### PR TITLE
Fetch All Replies Update 1: fetch top post as well

### DIFF
--- a/app/workers/fetch_reply_worker.rb
+++ b/app/workers/fetch_reply_worker.rb
@@ -7,6 +7,6 @@ class FetchReplyWorker
   sidekiq_options queue: 'pull', retry: 3
 
   def perform(child_url, options = {})
-    FetchRemoteStatusService.new.call(child_url, **options.deep_symbolize_keys)
+    FetchRemoteStatusService.new.call(child_url, **options.symbolize_keys)
   end
 end

--- a/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
+++ b/spec/workers/activitypub/fetch_all_replies_worker_spec.rb
@@ -140,6 +140,13 @@ RSpec.describe ActivityPub::FetchAllRepliesWorker do
       got_uris = subject.perform(status.id)
       expect(got_uris).to match_array(top_items + top_items_paged)
     end
+
+    it 'fetches the top status using a prefetched body' do
+      allow(FetchReplyWorker).to receive(:perform_async)
+      subject.perform(status.id)
+      expect(a_request(:get, top_note_uri)).to have_been_made.times(1)
+      expect(FetchReplyWorker).to have_received(:perform_async).with(top_note_uri, { 'prefetched_body' => top_object.deep_stringify_keys })
+    end
   end
 
   describe 'perform' do


### PR DESCRIPTION
Very small patch to fetch all replies since the upstream PR to use accurate counts data was merged, and it would be odd to have accurate counts for everything *except* the top status.

This is actually a perf neutral change - we already fetch the AP object to get the collections url. This just forwards that along to the FetchReplyWorker to update the status object if needed.

If tests pass here i'm gonna self-high-five merge this bc i want to deploy along with the upstream merge