### PR TITLE
expand wrapstodon range

### DIFF
--- a/app/lib/annual_report.rb
+++ b/app/lib/annual_report.rb
@@ -20,7 +20,12 @@ class AnnualReport
     return unless Setting.wrapstodon
 
     datetime = Time.now.utc
-    datetime.year if datetime.month == 12 && (10..31).cover?(datetime.day)
+
+    if datetime.month == 12 && (10..31).cover?(datetime.day)
+      datetime.year
+    elsif datetime.month == 1
+      datetime.year - 1
+    end
   end
 
   def initialize(account, year)


### PR DESCRIPTION
wrapstodon is not manually triggered anymore apparently, and now it is instead triggered within some hardcoded date range with a feature flag - https://github.com/mastodon/mastodon/issues/33150#issuecomment-3709168730

so this just expands the date range to include january because uhhhhh idk what happened in december