### PR TITLE
sticky posts

### DIFF
--- a/app/controllers/api/v1/statuses/stickies_controller.rb
+++ b/app/controllers/api/v1/statuses/stickies_controller.rb
@@ -1,30 +1,23 @@
 # frozen_string_literal: true
 
 class Api::V1::Statuses::StickiesController < Api::V1::Statuses::BaseController
-  include Authorization
-
-  before_action :set_status
-  # before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts', except: [:index, :show] }
-
-  # before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:reports' }, only: [:index, :show]
-  # before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:reports' }, except: [:show]
-
-  after_action :verify_authorized
-  # skip_before_action :set_status, only: [:destroy]
-
-  def show
-    render json: @status, serializer: REST::StatusSerializer
-  end
+  before_action -> { doorkeeper_authorize! :write, :'write:statuses' }
+  before_action :require_user!
+  before_action :require_manage_users!
 
   def create
-    Sticky.create(status_id: @status.id)
+    Sticky.find_or_create_by!(status: @status)
     render json: @status, serializer: REST::StatusSerializer
   end
 
   def destroy
-    @status.sticky.destroy
-    render json: @status, serializer: REST::StatusSerializer
-  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
-    not_found
+    @status.sticky&.destroy
+    render json: @status.reload, serializer: REST::StatusSerializer
+  end
+
+  private
+
+  def require_manage_users!
+    forbidden unless current_user&.role&.can?(:manage_users)
   end
 end

--- a/app/controllers/api/v1/statuses/stickies_controller.rb
+++ b/app/controllers/api/v1/statuses/stickies_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Api::V1::Statuses::StickiesController < Api::V1::Statuses::BaseController
+  include Authorization
+
+  before_action :set_status
+  # before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:accounts', except: [:index, :show] }
+
+  # before_action -> { authorize_if_got_token! :'admin:read', :'admin:read:reports' }, only: [:index, :show]
+  # before_action -> { authorize_if_got_token! :'admin:write', :'admin:write:reports' }, except: [:show]
+
+  after_action :verify_authorized
+  # skip_before_action :set_status, only: [:destroy]
+
+  def show
+    render json: @status, serializer: REST::StatusSerializer
+  end
+
+  def create
+    Sticky.create(status_id: @status.id)
+    render json: @status, serializer: REST::StatusSerializer
+  end
+
+  def destroy
+    @status.sticky.destroy
+    render json: @status, serializer: REST::StatusSerializer
+  rescue ActiveRecord::RecordNotFound, Mastodon::NotPermittedError
+    not_found
+  end
+end

--- a/app/javascript/flavours/glitch/actions/statuses.js
+++ b/app/javascript/flavours/glitch/actions/statuses.js
@@ -370,12 +370,11 @@ export const navigateToStatus = (statusId) => {
 
 export const toggleSticky = (statusId) => {
   return (dispatch, getState) => {
-    const state = getState();
-    const stickied = state.statuses.getIn([statusId, 'stickied']);
-    if (stickied) {
+    const isSticky = getState().statuses.getIn([statusId, 'sticky']);
+    if (isSticky) {
       dispatch(unsticky({statusId}))
     } else {
       dispatch(sticky({statusId}))
     }
   };
-}
+};

--- a/app/javascript/flavours/glitch/actions/statuses.js
+++ b/app/javascript/flavours/glitch/actions/statuses.js
@@ -7,7 +7,7 @@ import api from '../api';
 import { showAlert } from './alerts';
 import { ensureComposeIsVisible, setComposeToStatus } from './compose';
 import { importFetchedStatus, importFetchedAccount } from './importer';
-import { fetchContext } from './statuses_typed';
+import { fetchContext, sticky, unsticky } from './statuses_typed';
 import { deleteFromTimelines } from './timelines';
 
 export * from './statuses_typed';
@@ -367,3 +367,15 @@ export const navigateToStatus = (statusId) => {
     }
   };
 };
+
+export const toggleSticky = (statusId) => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const stickied = state.statuses.getIn([statusId, 'stickied']);
+    if (stickied) {
+      dispatch(unsticky({statusId}))
+    } else {
+      dispatch(sticky({statusId}))
+    }
+  };
+}

--- a/app/javascript/flavours/glitch/actions/statuses_typed.ts
+++ b/app/javascript/flavours/glitch/actions/statuses_typed.ts
@@ -1,6 +1,11 @@
 import { createAction } from '@reduxjs/toolkit';
 
-import { apiGetContext, apiSetQuotePolicy } from 'flavours/glitch/api/statuses';
+import {
+  apiGetContext,
+  apiSetQuotePolicy,
+  apiSticky,
+  apiUnsticky,
+} from 'flavours/glitch/api/statuses';
 import { createDataLoadingThunk } from 'flavours/glitch/store/typed_functions';
 
 import type { ApiQuotePolicy } from '../api_types/quotes';
@@ -41,4 +46,13 @@ export const setStatusQuotePolicy = createDataLoadingThunk(
   ({ statusId, policy }: { statusId: string; policy: ApiQuotePolicy }) => {
     return apiSetQuotePolicy(statusId, policy);
   },
+);
+
+export const sticky = createDataLoadingThunk(
+  'status/sticky',
+  ({ statusId }: { statusId: string }) => apiSticky(statusId),
+);
+export const unsticky = createDataLoadingThunk(
+  'status/unsticky',
+  ({ statusId }: { statusId: string }) => apiUnsticky(statusId),
 );

--- a/app/javascript/flavours/glitch/actions/statuses_typed.ts
+++ b/app/javascript/flavours/glitch/actions/statuses_typed.ts
@@ -10,7 +10,7 @@ import { createDataLoadingThunk } from 'flavours/glitch/store/typed_functions';
 
 import type { ApiQuotePolicy } from '../api_types/quotes';
 
-import { importFetchedStatuses } from './importer';
+import { importFetchedStatus, importFetchedStatuses } from './importer';
 
 export const fetchContext = createDataLoadingThunk(
   'status/context',
@@ -51,8 +51,14 @@ export const setStatusQuotePolicy = createDataLoadingThunk(
 export const sticky = createDataLoadingThunk(
   'status/sticky',
   ({ statusId }: { statusId: string }) => apiSticky(statusId),
+  (status, { dispatch }) => {
+    dispatch(importFetchedStatus(status));
+  },
 );
 export const unsticky = createDataLoadingThunk(
   'status/unsticky',
   ({ statusId }: { statusId: string }) => apiUnsticky(statusId),
+  (status, { dispatch }) => {
+    dispatch(importFetchedStatus(status));
+  },
 );

--- a/app/javascript/flavours/glitch/api/statuses.ts
+++ b/app/javascript/flavours/glitch/api/statuses.ts
@@ -31,15 +31,17 @@ export const apiSetQuotePolicy = async (
 };
 
 export const apiSticky = async (statusId: string) => {
-  await api().request<ApiContextJSON>({
+  const { data } = await api().request<ApiStatusJSON>({
     method: 'POST',
     url: `/api/v1/statuses/${statusId}/sticky`,
   });
+  return data;
 };
 
 export const apiUnsticky = async (statusId: string) => {
-  await api().request<ApiContextJSON>({
+  const { data } = await api().request<ApiStatusJSON>({
     method: 'POST',
     url: `/api/v1/statuses/${statusId}/unsticky`,
   });
+  return data;
 };

--- a/app/javascript/flavours/glitch/api/statuses.ts
+++ b/app/javascript/flavours/glitch/api/statuses.ts
@@ -29,3 +29,17 @@ export const apiSetQuotePolicy = async (
     },
   );
 };
+
+export const apiSticky = async (statusId: string) => {
+  await api().request<ApiContextJSON>({
+    method: 'POST',
+    url: `/api/v1/statuses/${statusId}/sticky`,
+  });
+};
+
+export const apiUnsticky = async (statusId: string) => {
+  await api().request<ApiContextJSON>({
+    method: 'POST',
+    url: `/api/v1/statuses/${statusId}/unsticky`,
+  });
+};

--- a/app/javascript/flavours/glitch/api_types/statuses.ts
+++ b/app/javascript/flavours/glitch/api_types/statuses.ts
@@ -125,6 +125,7 @@ export interface ApiStatusJSON {
   // glitch-soc additions
   local_only?: boolean;
   content_type?: string;
+  sticky?: boolean;
 }
 
 export interface ApiContextJSON {

--- a/app/javascript/flavours/glitch/components/status.jsx
+++ b/app/javascript/flavours/glitch/components/status.jsx
@@ -137,6 +137,7 @@ class Status extends ImmutablePureComponent {
       available: PropTypes.bool,
     }),
     contextType: PropTypes.string,
+    onSticky: PropTypes.func,
     ...WithOptionalRouterPropTypes,
   };
 
@@ -746,6 +747,7 @@ class Status extends ImmutablePureComponent {
                 'status--is-quote': isQuotedPost,
                 'status--has-quote': !!status.get('quote'),
                 'status--highlighted-entry': this.props.shouldHighlightOnMount,
+                'status--sticky': !!status.get('sticky'),
               })
             }
             data-id={status.get('id')}

--- a/app/javascript/flavours/glitch/components/status_action_bar/index.jsx
+++ b/app/javascript/flavours/glitch/components/status_action_bar/index.jsx
@@ -65,6 +65,8 @@ const messages = defineMessages({
   openOriginalPage: { id: 'account.open_original_page', defaultMessage: 'Open original page' },
   revokeQuote: { id: 'status.revoke_quote', defaultMessage: 'Remove my post from @{name}’s post' },
   quotePolicyChange: { id: 'status.quote_policy_change', defaultMessage: 'Change who can quote' },
+  sticky: { id: 'status.sticky.make_sticky', defaultMessage: 'Make this post globally sticky' },
+  unsticky: { id: 'status.sticky.unsticky', defaultMessage: 'Unsticky this post' }
 });
 
 const mapStateToProps = (state, { status }) => {
@@ -99,6 +101,7 @@ class StatusActionBar extends ImmutablePureComponent {
     onFilter: PropTypes.func,
     onAddFilter: PropTypes.func,
     onInteractionModal: PropTypes.func,
+    onSticky: PropTypes.func,
     withDismiss: PropTypes.bool,
     withCounters: PropTypes.bool,
     showReplyCount: PropTypes.bool,
@@ -222,6 +225,11 @@ class StatusActionBar extends ImmutablePureComponent {
     this.props.onFilter();
   };
 
+  handleSticky = () => {
+    this.props.onSticky(this.props.status);
+  };
+
+
   render () {
     const { status, statusQuoteState, quotedAccountId, contextType, intl, withDismiss, withCounters, showReplyCount, scrollKey } = this.props;
     const { signedIn, permissions } = this.props.identity;
@@ -232,6 +240,7 @@ class StatusActionBar extends ImmutablePureComponent {
     const writtenByMe        = status.getIn(['account', 'id']) === me;
     const isRemote           = status.getIn(['account', 'username']) !== status.getIn(['account', 'acct']);
     const isQuotingMe        = quotedAccountId === me;
+    const isSticky = status.get('sticky')
 
     let menu = [];
     let reblogIcon = 'retweet';
@@ -317,6 +326,16 @@ class StatusActionBar extends ImmutablePureComponent {
             const domain = status.getIn(['account', 'acct']).split('@')[1];
             menu.push({ text: intl.formatMessage(messages.admin_domain, { domain: domain }), href: `/admin/instances/${domain}` });
           }
+        }
+      }
+
+      // Sticky/unsticky post
+      if (!isRemote && ((permissions & PERMISSION_MANAGE_USERS) === PERMISSION_MANAGE_USERS)) {
+        menu.push(null);
+        if (isSticky){
+          menu.push({ text: intl.formatMessage(messages.unsticky), action: this.handleSticky })
+        } else {
+          menu.push({ text: intl.formatMessage(messages.sticky), action: this.handleSticky })
         }
       }
     }

--- a/app/javascript/flavours/glitch/components/status_icons.jsx
+++ b/app/javascript/flavours/glitch/components/status_icons.jsx
@@ -56,6 +56,7 @@ class StatusIcons extends PureComponent {
 
     return (
       <div className='status__info__icons'>
+        {status.get('sticky') && <span className={"sticky-token"}>STICKY</span>}
         {settings.get('language') && status.get('language') && <LanguageIcon language={status.get('language')} />}
         {settings.get('reply') && status.get('in_reply_to_id', null) !== null ? (
           <Icon

--- a/app/javascript/flavours/glitch/containers/status_container.js
+++ b/app/javascript/flavours/glitch/containers/status_container.js
@@ -245,10 +245,6 @@ const mapDispatchToProps = (dispatch, { contextType }) => ({
     dispatch(toggleSticky(status.get('id')));
   },
 
-  onUnsticky (status) {
-    dispatch(toggleSticky(status.get('id')));
-  }
-
 });
 
 export default connect(makeMapStateToProps, mapDispatchToProps)(Status);

--- a/app/javascript/flavours/glitch/containers/status_container.js
+++ b/app/javascript/flavours/glitch/containers/status_container.js
@@ -28,6 +28,7 @@ import {
   deleteStatus,
   toggleStatusSpoilers,
   toggleStatusCollapse,
+  toggleSticky,
   editStatus,
   translateStatus,
   undoStatusTranslation,
@@ -239,6 +240,14 @@ const mapDispatchToProps = (dispatch, { contextType }) => ({
       },
     }));
   },
+
+  onSticky (status) {
+    dispatch(toggleSticky(status.get('id')));
+  },
+
+  onUnsticky (status) {
+    dispatch(toggleSticky(status.get('id')));
+  }
 
 });
 

--- a/app/javascript/flavours/glitch/locales/en.json
+++ b/app/javascript/flavours/glitch/locales/en.json
@@ -122,5 +122,7 @@
   "status.in_reply_to": "This toot is a reply",
   "status.is_poll": "This toot is a poll",
   "status.local_only": "Only visible from your instance",
-  "status.show_filter_reason": "Show anyway"
+  "status.show_filter_reason": "Show anyway",
+  "status.sticky.make_sticky": "Make this post globally sticky",
+  "status.sticky.unsticky": "Unsticky this post"
 }

--- a/app/javascript/flavours/glitch/styles/neuromatchstodon/index.scss
+++ b/app/javascript/flavours/glitch/styles/neuromatchstodon/index.scss
@@ -1,3 +1,4 @@
 @use 'latex';
 @use 'better_code_blocks';
 @use 'myspace';
+@use 'sticky';

--- a/app/javascript/flavours/glitch/styles/neuromatchstodon/sticky.scss
+++ b/app/javascript/flavours/glitch/styles/neuromatchstodon/sticky.scss
@@ -1,0 +1,15 @@
+.status--sticky {
+  border-color: var(--color-border-warning-soft);
+  background-color: var(--color-bg-secondary);
+
+  .display-name {
+    color: var(--color-text-warning);
+  }
+}
+
+.sticky-token {
+  border: 1px solid var(--color-border-warning-soft);
+  border-radius: 0.25em;
+  padding: 0 0.1em;
+  color: var(--color-text-warning);
+}

--- a/app/lib/status_cache_hydrator.rb
+++ b/app/lib/status_cache_hydrator.rb
@@ -57,7 +57,7 @@ class StatusCacheHydrator
     payload[:bookmarked] = Bookmark.exists?(account_id: account_id, status_id: status.id)
     payload[:pinned]     = StatusPin.exists?(account_id: account_id, status_id: status.id) if status.account_id == account_id
     payload[:filtered]   = mapped_applied_custom_filter(account_id, status)
-    payload[:sticky]     = Sticky.exists?(status_id: status.id)
+    payload[:sticky]     = Sticky.stickies.include? status.id
     # TODO: performance optimization by not loading `Account` twice
     payload[:quote_approval][:current_user] = status.quote_policy_for_account(Account.find_by(id: account_id)) if payload[:quote_approval]
     payload[:quote] = hydrate_quote_payload(payload[:quote], status.quote, account_id, nested:) if payload[:quote]

--- a/app/lib/status_cache_hydrator.rb
+++ b/app/lib/status_cache_hydrator.rb
@@ -46,6 +46,7 @@ class StatusCacheHydrator
       payload[:favourited] = payload[:reblog][:favourited]
       payload[:reblogged]  = payload[:reblog][:reblogged]
       payload[:quote_approval] = payload[:reblog][:quote_approval]
+      payload[:sticky] = false
     end
   end
 
@@ -56,6 +57,7 @@ class StatusCacheHydrator
     payload[:bookmarked] = Bookmark.exists?(account_id: account_id, status_id: status.id)
     payload[:pinned]     = StatusPin.exists?(account_id: account_id, status_id: status.id) if status.account_id == account_id
     payload[:filtered]   = mapped_applied_custom_filter(account_id, status)
+    payload[:sticky]     = Sticky.exists?(status_id: status.id)
     # TODO: performance optimization by not loading `Account` twice
     payload[:quote_approval][:current_user] = status.quote_policy_for_account(Account.find_by(id: account_id)) if payload[:quote_approval]
     payload[:quote] = hydrate_quote_payload(payload[:quote], status.quote, account_id, nested:) if payload[:quote]

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -28,6 +28,9 @@ class Feed
       unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map { |id| id.first.to_i }
     end
 
+    # prepend stickies!
+    # TODO but this is where to do it!!!
+
     Status.where(id: unhydrated)
   end
 

--- a/app/models/feed.rb
+++ b/app/models/feed.rb
@@ -28,9 +28,6 @@ class Feed
       unhydrated = redis.zrangebyscore(key, "(#{min_id}", "(#{max_id}", limit: [0, limit], with_scores: true).map { |id| id.first.to_i }
     end
 
-    # prepend stickies!
-    # TODO but this is where to do it!!!
-
     Status.where(id: unhydrated)
   end
 

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -10,7 +10,7 @@ class HomeFeed < Feed
     results = super
     return results if max_id.present? || min_id.present?
 
-    prepend_stickies(results, Sticky.recent_statuses_for_feed)
+    prepend_stickies(results, Sticky.stickied_statuses)
   end
 
   def async_refresh

--- a/app/models/home_feed.rb
+++ b/app/models/home_feed.rb
@@ -6,6 +6,13 @@ class HomeFeed < Feed
     super(:home, account.id)
   end
 
+  def get(limit, max_id = nil, since_id = nil, min_id = nil)
+    results = super
+    return results if max_id.present? || min_id.present?
+
+    prepend_stickies(results, Sticky.recent_statuses_for_feed)
+  end
+
   def async_refresh
     @async_refresh ||= AsyncRefresh.new(redis_regeneration_key)
   end
@@ -29,6 +36,12 @@ class HomeFeed < Feed
   end
 
   private
+
+  def prepend_stickies(results, stickies)
+    stickies = stickies.to_a
+    sticky_ids = stickies.to_set(&:id)
+    stickies + results.to_a.reject { |s| sticky_ids.include?(s.id) }
+  end
 
   def redis_regeneration_key
     @redis_regeneration_key = "account:#{@account.id}:regeneration"

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -35,12 +35,23 @@ class PublicFeed
 
     scope.merge!(without_duplicate_reblogs) if with_reblogs?
 
-    scope.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
+    results = scope.to_a_paginated_by_id(limit, max_id: max_id, since_id: since_id, min_id: min_id)
+    return results if max_id.present? || min_id.present?
+
+    prepend_stickies(results)
   end
 
   private
 
   attr_reader :account, :options
+
+  def prepend_stickies(results)
+    return results unless allow_local_only?
+
+    stickies = Sticky.recent_statuses_for_feed.to_a
+    sticky_ids = stickies.to_set(&:id)
+    stickies + results.to_a.reject { |s| sticky_ids.include?(s.id) }
+  end
 
   def allow_local_only?
     local_account? && (local_only? || options[:allow_local_only])

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -48,7 +48,7 @@ class PublicFeed
   def prepend_stickies(results)
     return results unless allow_local_only?
 
-    stickies = Sticky.recent_statuses_for_feed.to_a
+    stickies = Sticky.stickied_statuses.to_a
     sticky_ids = stickies.to_set(&:id)
     stickies + results.to_a.reject { |s| sticky_ids.include?(s.id) }
   end

--- a/app/models/public_feed.rb
+++ b/app/models/public_feed.rb
@@ -46,7 +46,7 @@ class PublicFeed
   attr_reader :account, :options
 
   def prepend_stickies(results)
-    return results unless allow_local_only?
+    return results unless local_account?
 
     stickies = Sticky.stickied_statuses.to_a
     sticky_ids = stickies.to_set(&:id)

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -471,7 +471,7 @@ class Status < ApplicationRecord
   end
 
   def sticky?
-    Sticky.exists?(status_id: id)
+    Sticky.stickies.include? id
   end
 
   private

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -118,6 +118,7 @@ class Status < ApplicationRecord
   has_one :poll, inverse_of: :status, dependent: :destroy
   has_one :trend, class_name: 'StatusTrend', inverse_of: :status, dependent: nil
   has_one :quote, inverse_of: :status, dependent: :destroy
+  has_one :sticky, inverse_of: :status, dependent: :destroy
 
   validates :uri, uniqueness: true, presence: true, unless: :local?
   validates :text, presence: true, unless: -> { with_media? || reblog? || with_quote? }
@@ -467,6 +468,10 @@ class Status < ApplicationRecord
     inbox_owners.each do |inbox_owner|
       AccountConversation.remove_status(inbox_owner, self)
     end
+  end
+
+  def sticky?
+    Sticky.exists?(status_id: id)
   end
 
   private

--- a/app/models/sticky.rb
+++ b/app/models/sticky.rb
@@ -16,6 +16,7 @@ class Sticky < ApplicationRecord
 
   scope :stickied_statuses, lambda {
     Status.local
+      .distributable_visibility
       .joins(:sticky)
       .reorder('stickies.created_at DESC')
   }

--- a/app/models/sticky.rb
+++ b/app/models/sticky.rb
@@ -13,4 +13,10 @@
 #
 class Sticky < ApplicationRecord
   belongs_to :status
+
+  scope :stickied_statuses, lambda {
+    Status.local
+      .joins(:sticky)
+      .reorder('stickies.created_at DESC')
+  }
 end

--- a/app/models/sticky.rb
+++ b/app/models/sticky.rb
@@ -12,6 +12,8 @@
 #  status_id  :bigint(8)        not null
 #
 class Sticky < ApplicationRecord
+  include Redisable
+
   belongs_to :status
 
   scope :stickied_statuses, lambda {
@@ -20,4 +22,23 @@ class Sticky < ApplicationRecord
       .joins(:sticky)
       .reorder('stickies.created_at DESC')
   }
+
+  after_create :clear_cache
+  after_destroy :clear_cache
+
+  # Cached set of sticky status IDs used to check for status stickiness without an extra query
+  # There are only ever a small number of stickies and they change slowly.
+  #
+  # @return Set<Integer>
+  def self.stickies
+    Rails.cache.fetch('stickies', expires_in: 1.day) do
+      Sticky.reorder('stickies.created_at DESC').pluck(:status_id).to_set
+    end
+  end
+
+  private
+
+  def clear_cache
+    Rails.cache.delete('stickies')
+  end
 end

--- a/app/models/sticky.rb
+++ b/app/models/sticky.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Mark a status as sticky! Show it at the top of home and local feeds.
+#
+# == Schema Information
+#
+# Table name: stickies
+#
+#  id         :bigint(8)        not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  status_id  :bigint(8)        not null
+#
+class Sticky < ApplicationRecord
+  belongs_to :status
+end

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -16,7 +16,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :bookmarked, if: :current_user?
   attribute :pinned, if: :pinnable?
   attribute :local_only, if: :local?
-  attribute :sticky?, if: :sticky?
+  attribute :sticky, if: :current_user?
   has_many :filtered, serializer: REST::FilterResultSerializer, if: :current_user?
 
   attribute :content, unless: :source_requested?
@@ -41,7 +41,10 @@ class REST::StatusSerializer < ActiveModel::Serializer
   has_one :quote_approval
 
   delegate :local?, to: :object
-  delegate :sticky?, to: :object
+
+  def sticky
+    object.sticky?
+  end
 
   def quote
     object.quote if object.quote&.acceptable?

--- a/app/serializers/rest/status_serializer.rb
+++ b/app/serializers/rest/status_serializer.rb
@@ -16,6 +16,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   attribute :bookmarked, if: :current_user?
   attribute :pinned, if: :pinnable?
   attribute :local_only, if: :local?
+  attribute :sticky?, if: :sticky?
   has_many :filtered, serializer: REST::FilterResultSerializer, if: :current_user?
 
   attribute :content, unless: :source_requested?
@@ -40,6 +41,7 @@ class REST::StatusSerializer < ActiveModel::Serializer
   has_one :quote_approval
 
   delegate :local?, to: :object
+  delegate :sticky?, to: :object
 
   def quote
     object.quote if object.quote&.acceptable?

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -56,8 +56,8 @@ namespace :api, format: false do
 
         post :translate, to: 'translations#create'
 
-        resource :sticky, to: 'stickies#create', only: :create
-        post :unsticky, to: 'sticky#destroy'
+        post :sticky, to: 'stickies#create'
+        post :unsticky, to: 'stickies#destroy'
       end
 
       member do

--- a/config/routes/api.rb
+++ b/config/routes/api.rb
@@ -55,6 +55,9 @@ namespace :api, format: false do
         resource :interaction_policy, only: :update
 
         post :translate, to: 'translations#create'
+
+        resource :sticky, to: 'stickies#create', only: :create
+        post :unsticky, to: 'sticky#destroy'
       end
 
       member do

--- a/db/migrate/20260516044825_create_stickies.rb
+++ b/db/migrate/20260516044825_create_stickies.rb
@@ -3,7 +3,7 @@
 class CreateStickies < ActiveRecord::Migration[8.0]
   def change
     create_table :stickies do |t|
-      t.references :status, null: false, foreign_key: true
+      t.references :status, null: false, foreign_key: true, index: { unique: true }
 
       t.timestamps
     end

--- a/db/migrate/20260516044825_create_stickies.rb
+++ b/db/migrate/20260516044825_create_stickies.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateStickies < ActiveRecord::Migration[8.0]
+  def change
+    create_table :stickies do |t|
+      t.references :status, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_05_155103) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_16_044825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -1258,6 +1258,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_155103) do
     t.index ["status_id"], name: "index_statuses_tags_on_status_id"
   end
 
+  create_table "stickies", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "status_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status_id"], name: "index_stickies_on_status_id"
+  end
+
   create_table "tag_follows", force: :cascade do |t|
     t.bigint "account_id", null: false
     t.datetime "created_at", null: false
@@ -1594,6 +1601,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_05_155103) do
   add_foreign_key "statuses", "statuses", column: "reblog_of_id", on_delete: :cascade
   add_foreign_key "statuses_tags", "statuses", on_delete: :cascade
   add_foreign_key "statuses_tags", "tags", name: "fk_3081861e21", on_delete: :cascade
+  add_foreign_key "stickies", "statuses"
   add_foreign_key "tag_follows", "accounts", on_delete: :cascade
   add_foreign_key "tag_follows", "tags", on_delete: :cascade
   add_foreign_key "tag_trends", "tags", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1262,7 +1262,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_16_044825) do
     t.datetime "created_at", null: false
     t.bigint "status_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["status_id"], name: "index_stickies_on_status_id"
+    t.index ["status_id"], name: "index_stickies_on_status_id", unique: true
   end
 
   create_table "tag_follows", force: :cascade do |t|

--- a/spec/fabricators/sticky_fabricator.rb
+++ b/spec/fabricators/sticky_fabricator.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Fabricator(:sticky) do
+  status
+end

--- a/spec/models/home_feed_spec.rb
+++ b/spec/models/home_feed_spec.rb
@@ -122,4 +122,39 @@ RSpec.describe HomeFeed do
       expect(redis.hget("account:#{account.id}:regeneration", 'status')).to eq 'finished'
     end
   end
+
+  describe '#get with stickies' do
+    let!(:older_sticky_status) { Fabricate(:status, visibility: :public) }
+    let!(:newer_sticky_status) { Fabricate(:status, visibility: :public) }
+    let!(:normal_status_in_feed) { Fabricate(:status, account: account) }
+
+    before do
+      Sticky.create!(status: older_sticky_status, created_at: 2.hours.ago)
+      Sticky.create!(status: newer_sticky_status, created_at: 1.hour.ago)
+      redis.zadd(
+        FeedManager.instance.key(:home, account.id),
+        [[normal_status_in_feed.id, normal_status_in_feed.id]]
+      )
+    end
+
+    it 'prepends stickies at the top of the first page, newest first' do
+      ids = subject.get(20).map(&:id)
+      expect(ids.first(2)).to eq [newer_sticky_status.id, older_sticky_status.id]
+      expect(ids).to include(normal_status_in_feed.id)
+    end
+
+    it 'does not prepend stickies on paginated requests with max_id' do
+      ids = subject.get(20, normal_status_in_feed.id).map(&:id)
+      expect(ids).to_not include(newer_sticky_status.id, older_sticky_status.id)
+    end
+
+    it 'deduplicates a sticky that would appear naturally in the feed' do
+      redis.zadd(
+        FeedManager.instance.key(:home, account.id),
+        [[newer_sticky_status.id, newer_sticky_status.id]]
+      )
+      ids = subject.get(20).map(&:id)
+      expect(ids.count(newer_sticky_status.id)).to eq 1
+    end
+  end
 end

--- a/spec/models/public_feed_spec.rb
+++ b/spec/models/public_feed_spec.rb
@@ -719,4 +719,34 @@ RSpec.describe PublicFeed do
       end
     end
   end
+
+  describe '#get with stickies' do
+    subject { described_class.new(local_account) }
+
+    let!(:local_account) { Fabricate(:account, domain: nil) }
+    let!(:older_sticky_status) { Fabricate(:status, id: 1, created_at: 3.hours.ago, visibility: :public, account: local_account) }
+    let!(:newer_sticky_status) { Fabricate(:status, id: 3, created_at: 1.hour.ago, visibility: :public, account: local_account) }
+    let!(:normal_status) { Fabricate(:status, id: 2, created_at: 2.hours.ago, visibility: :public, account: local_account) }
+
+    before do
+      Sticky.create!(status: older_sticky_status, created_at: 2.hours.ago)
+      Sticky.create!(status: newer_sticky_status, created_at: 1.hour.ago)
+    end
+
+    it 'prepends stickies at the top of the first page, newest first' do
+      ids = subject.get(20).map(&:id)
+      expect(ids.first(2)).to eq [newer_sticky_status.id, older_sticky_status.id]
+      expect(ids).to include(normal_status.id)
+    end
+
+    it 'deduplicates a sticky that would also appear naturally in the feed' do
+      ids = subject.get(20).map(&:id)
+      expect(ids.count(newer_sticky_status.id)).to eq 1
+    end
+
+    it 'does not pin stickies on paginated requests with max_id' do
+      ids = subject.get(20, normal_status.id).map(&:id)
+      expect(ids).to eq [older_sticky_status.id]
+    end
+  end
 end

--- a/spec/models/sticky_spec.rb
+++ b/spec/models/sticky_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Sticky do
+  describe 'Validations' do
+    it 'requires a status' do
+      sticky = described_class.new
+      expect(sticky).to_not be_valid
+      expect(sticky.errors[:status]).to be_present
+    end
+  end
+
+  describe 'Association' do
+    it 'is destroyed when the parent status is destroyed' do
+      status = Fabricate(:status)
+      described_class.create!(status: status)
+
+      expect { status.destroy }.to change(described_class, :count).by(-1)
+    end
+  end
+
+  describe '.stickied_statuses' do
+    let!(:older_sticky_status) { Fabricate(:status, visibility: :public) }
+    let!(:newer_sticky_status) { Fabricate(:status, visibility: :public) }
+
+    before do
+      described_class.create!(status: older_sticky_status, created_at: 2.hours.ago)
+      described_class.create!(status: newer_sticky_status, created_at: 1.hour.ago)
+    end
+
+    it 'returns sticky statuses ordered by sticky creation desc' do
+      expect(described_class.stickied_statuses.to_a).to eq [newer_sticky_status, older_sticky_status]
+    end
+
+    it 'excludes private and direct statuses' do
+      private_status = Fabricate(:status, visibility: :private)
+      direct_status = Fabricate(:status, visibility: :direct)
+      described_class.create!(status: private_status)
+      described_class.create!(status: direct_status)
+
+      ids = described_class.stickied_statuses.pluck(:id)
+      expect(ids).to_not include(private_status.id, direct_status.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/statuses/stickies_spec.rb
+++ b/spec/requests/api/v1/statuses/stickies_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Stickies' do
+  let(:user)    { Fabricate(:moderator_user) }
+  let(:scopes)  { 'write:statuses' }
+  let(:token)   { Fabricate(:accessible_access_token, resource_owner_id: user.id, scopes: scopes) }
+  let(:headers) { { 'Authorization' => "Bearer #{token.token}" } }
+
+  describe 'POST /api/v1/statuses/:status_id/sticky' do
+    subject do
+      post "/api/v1/statuses/#{status.id}/sticky", headers: headers
+    end
+
+    let(:status) { Fabricate(:status) }
+
+    it_behaves_like 'forbidden for wrong scope', 'read'
+
+    context 'when a moderator' do
+      it 'creates a sticky and returns updated json with sticky: true', :aggregate_failures do
+        subject
+
+        expect(response).to have_http_status(200)
+        expect(Sticky.exists?(status_id: status.id)).to be true
+        expect(response.parsed_body).to match(
+          a_hash_including(id: status.id.to_s, sticky: true)
+        )
+        expect(response.parsed_body.keys.map(&:to_s)).to include('sticky')
+      end
+
+      it 'is idempotent when called twice' do
+        subject
+        expect { post "/api/v1/statuses/#{status.id}/sticky", headers: headers }
+          .to_not change(Sticky, :count)
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    context 'when a regular user' do
+      let(:user) { Fabricate(:user) }
+
+      it 'returns http forbidden' do
+        subject
+        expect(response).to have_http_status(403)
+      end
+    end
+
+    context 'without an authorization header' do
+      let(:headers) { {} }
+
+      it 'returns http unauthorized' do
+        subject
+        expect(response).to have_http_status(401)
+      end
+    end
+
+    context 'when the status does not exist' do
+      it 'returns http not found' do
+        post '/api/v1/statuses/-1/sticky', headers: headers
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+
+  describe 'POST /api/v1/statuses/:status_id/unsticky' do
+    subject do
+      post "/api/v1/statuses/#{status.id}/unsticky", headers: headers
+    end
+
+    let(:status) { Fabricate(:status) }
+
+    it_behaves_like 'forbidden for wrong scope', 'read'
+
+    context 'when a moderator' do
+      context 'when the status is currently sticky' do
+        before { Sticky.create!(status: status) }
+
+        it 'removes the sticky and returns updated json with sticky: false', :aggregate_failures do
+          subject
+
+          expect(response).to have_http_status(200)
+          expect(Sticky.exists?(status_id: status.id)).to be false
+          expect(response.parsed_body).to match(
+            a_hash_including(id: status.id.to_s, sticky: false)
+          )
+        end
+      end
+
+      context 'when the status is not sticky' do
+        it 'returns http success without error' do
+          subject
+          expect(response).to have_http_status(200)
+          expect(response.parsed_body).to match(
+            a_hash_including(id: status.id.to_s, sticky: false)
+          )
+        end
+      end
+    end
+
+    context 'when a regular user' do
+      let(:user) { Fabricate(:user) }
+
+      before { Sticky.create!(status: status) }
+
+      it 'returns http forbidden and does not remove the sticky', :aggregate_failures do
+        subject
+        expect(response).to have_http_status(403)
+        expect(Sticky.exists?(status_id: status.id)).to be true
+      end
+    end
+  end
+end

--- a/spec/system/stickies_spec.rb
+++ b/spec/system/stickies_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'Sticky posts', :inline_jobs, :js do
+RSpec.describe 'Sticky posts', :inline_jobs, :js, :streaming do
   include ProfileStories
 
   let(:email)               { 'test@example.com' }
@@ -27,7 +27,8 @@ RSpec.describe 'Sticky posts', :inline_jobs, :js do
     expect(page).to have_css('.status', text: 'Hello from Alice')
 
     within(first('.status')) do
-      find('button[title="More"]').click_button
+      # rubocop:disable Capybara/SpecificActions
+      find('button[title="More"]').click
     end
 
     within('.dropdown-menu') do
@@ -36,7 +37,7 @@ RSpec.describe 'Sticky posts', :inline_jobs, :js do
     end
 
     within(first('.status')) do
-      find('button[title="More"]').click_button
+      find('button[title="More"]').click
     end
 
     within('.dropdown-menu') do
@@ -54,7 +55,7 @@ RSpec.describe 'Sticky posts', :inline_jobs, :js do
     visit '/public/local'
 
     within(first('.status')) do
-      find('button[title="More"]').click_button
+      find('button[title="More"]').click
     end
 
     within('.dropdown-menu') do
@@ -63,7 +64,8 @@ RSpec.describe 'Sticky posts', :inline_jobs, :js do
 
     # Reopen and confirm we're back to "Make sticky"
     within(first('.status')) do
-      find('button[title="More"]').click_button
+      find('button[title="More"]').click
+      # rubocop:enable Capybara/SpecificActions
     end
 
     within('.dropdown-menu') do

--- a/spec/system/stickies_spec.rb
+++ b/spec/system/stickies_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Sticky posts', :inline_jobs, :js do
+  include ProfileStories
+
+  let(:email)               { 'test@example.com' }
+  let(:password)            { 'password' }
+  let(:confirmed_at)        { Time.zone.now }
+  let(:finished_onboarding) { true }
+  let!(:other_account)      { Fabricate(:account, username: 'alice') }
+  let!(:target_status)      { Fabricate(:status, account: other_account, text: 'Hello from Alice', visibility: :public) }
+
+  before do
+    Setting.local_live_feed_access = 'public'
+    as_a_logged_in_user
+    bob.update!(role: UserRole.find_by!(name: 'Moderator'))
+    page.refresh
+  end
+
+  it 'toggles stickiness from off to on' do
+    ignore_js_error(/Failed to load resource/)
+
+    visit '/public/local'
+
+    expect(page).to have_css('.status', text: 'Hello from Alice')
+
+    within(first('.status')) do
+      find('button[title="More"]').click_button
+    end
+
+    within('.dropdown-menu') do
+      expect(page).to have_text('Make this post globally sticky')
+      click_on 'Make this post globally sticky'
+    end
+
+    within(first('.status')) do
+      find('button[title="More"]').click_button
+    end
+
+    within('.dropdown-menu') do
+      expect(page).to have_text('Unsticky this post')
+    end
+
+    expect(Sticky.exists?(status_id: target_status.id)).to be true
+  end
+
+  it 'toggles stickiness from on to off' do
+    Sticky.create!(status: target_status)
+
+    ignore_js_error(/Failed to load resource/)
+
+    visit '/public/local'
+
+    within(first('.status')) do
+      find('button[title="More"]').click_button
+    end
+
+    within('.dropdown-menu') do
+      click_on 'Unsticky this post'
+    end
+
+    # Reopen and confirm we're back to "Make sticky"
+    within(first('.status')) do
+      find('button[title="More"]').click_button
+    end
+
+    within('.dropdown-menu') do
+      expect(page).to have_text('Make this post globally sticky')
+    end
+
+    expect(Sticky.exists?(status_id: target_status.id)).to be false
+  end
+end


### PR DESCRIPTION
Make posts globally sticky!

opening as a messay draft, there is just so much mother fucking boilerplate to do to add a single fucking bool

> i have it so the frontend is calling the backend and it is creating the sticky, but i can't get the response to then propagate back into the redux state/load properly. and there is one line where we need to load the statuses with stickies but that's not done, but i figure that's just the last touch needed after the frontend state stuff is worked out. it shoudl be super simple but it's fucking not and i hate it

---

ok done,

looks something like this

<img width="644" height="700" alt="Screenshot 2026-05-16 at 9 02 23 PM" src="https://github.com/user-attachments/assets/452431e9-9423-4390-9ee0-2d5158edd350" />

where a moderator can choose to make a post sticky or not from the status menu

<img width="443" height="487" alt="Screenshot 2026-05-16 at 10 16 34 PM" src="https://github.com/user-attachments/assets/77a8d301-7509-42ec-97a7-21478217271a" />

